### PR TITLE
Improve error handling in client

### DIFF
--- a/pdc_client/utils.py
+++ b/pdc_client/utils.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2015 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+from __future__ import print_function
+
+import sys
+
+
+def _pprint_str(file, s, indent, lead=''):
+    """Print indented string with optional leading text."""
+    print(' ' * indent + lead + s, file=file)
+
+
+def _pprint_list(file, items, indent):
+    """Print an indented bullet point list."""
+    for item in items:
+        _pprint_str(file, item, indent, lead='* ')
+
+
+def _pprint_dict(file, data, indent):
+    """Print a dict as an indented definition list."""
+    for key, value in data.iteritems():
+        _pprint_str(file, key + ':', indent)
+        pretty_print(value, indent + 1, file)
+
+
+def pretty_print(data, indent=0, file=sys.stdout):
+    """Pretty print a data structure."""
+    if isinstance(data, basestring):
+        _pprint_list(file, [data], indent)
+    elif isinstance(data, list):
+        _pprint_list(file, data, indent)
+    elif isinstance(data, dict):
+        _pprint_dict(file, data, indent)
+    else:
+        raise TypeError('Can not handle {}'.format(type(data)))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -5,8 +5,10 @@
 # http://opensource.org/licenses/MIT
 #
 import unittest
+from StringIO import StringIO
 
 from pdc_client import plugin_helpers
+from pdc_client import utils
 
 
 class PluginHelperTestCase(unittest.TestCase):
@@ -19,3 +21,26 @@ class PluginHelperTestCase(unittest.TestCase):
         data = plugin_helpers.extract_arguments(args, prefix='prf__')
         self.assertDictEqual(data,
                              {'foo': {'bar': {'baz': 1, 'quux': 2}}})
+
+
+class PrettyPrinterTestCase(unittest.TestCase):
+    def setUp(self):
+        self.out = StringIO()
+
+    def tearDown(self):
+        self.out.close()
+
+    def test_print_list(self):
+        utils.pretty_print(['foo', 'bar', 'baz'], file=self.out)
+        self.assertEqual(self.out.getvalue(),
+                         '* foo\n* bar\n* baz\n')
+
+    def test_print_dict(self):
+        utils.pretty_print({'foo': 'bar'}, file=self.out)
+        self.assertEqual(self.out.getvalue(),
+                         'foo:\n * bar\n')
+
+    def test_print_nested_dict(self):
+        utils.pretty_print({'foo': {'bar': ['baz', 'quux']}}, file=self.out)
+        self.assertEqual(self.out.getvalue(),
+                         'foo:\n bar:\n  * baz\n  * quux\n')


### PR DESCRIPTION
When network request fails, the error printing is more robust. Ideally,
the error response should be JSON encoded. In that case it will be
pretty printed.

If JSON parsing or pretty printing fails, user is prompted to file a
bug. The response data is logged only if it was valid JSON, as the only
case of non-JSON responses is a huge HTML dump.

The error is now consistently printed to stderr.

JIRA: PDC-1193
