### PR TITLE
Update globle-component with its name instead of its id

### DIFF
--- a/tests/component/tests.py
+++ b/tests/component/tests.py
@@ -100,6 +100,7 @@ class GlobalComponentTestCase(CLITestCase):
                               })
 
     def test_update(self, api):
+        api.add_endpoint('global-components', 'GET', [self.detail])
         self._setup_detail(api)
         api.add_endpoint('global-component-contacts',
                          'GET',
@@ -120,16 +121,11 @@ class GlobalComponentTestCase(CLITestCase):
                           ]})
         api.add_endpoint('global-components/1', 'PATCH', {})
         with self.expect_output('global_component/detail.txt'):
-            self.runner.run(['global-component', 'update', '1', '--name', 'new test name'])
+            self.runner.run(['global-component', 'update', 'Test Global Component', '--name', 'new test name'])
         self.assertDictEqual(api.calls,
-                             {'global-components/1': [('PATCH', {'name': 'new test name'}),
-                                                      ('GET', {})],
-                              'global-component-contacts':
-                                  [('GET',
-                                    {'component': 'Test Global Component',
-                                     'page': 1})
-                                   ]
-                              })
+                             {'global-components': [('GET', {'name': 'Test Global Component'})],
+                              'global-components/1': [('PATCH', {'name': 'new test name'}), ('GET', {})],
+                              'global-component-contacts': [('GET', {'component': 'Test Global Component', 'page': 1})]})
 
     def test_create(self, api):
         api.add_endpoint('global-component-contacts',


### PR DESCRIPTION
When using pdc command to update globale-component,
we change to use global-component's name instead of
its id as Input Parameter.

JIRA: PDC-1157
