### PR TITLE
Make mocked endpoints possibly callable.

### DIFF
--- a/pdc_client/test_helpers.py
+++ b/pdc_client/test_helpers.py
@@ -92,14 +92,22 @@ class MockAPI(object):
 
     def _handle_post(self, data):
         self.calls.setdefault(self.will_call, []).append(('POST', data))
-        return self.endpoints[self.will_call]['POST']
+        data = self.endpoints[self.will_call]['POST']
+        if callable(data):
+            data = data()
+        return data
 
     def _handle_delete(self, data):
         self.calls.setdefault(self.will_call, []).append(('DELETE', data))
-        return self.endpoints[self.will_call]['DELETE']
+        data = self.endpoints[self.will_call]['DELETE']
+        if callable(data):
+            data = data()
+        return data
 
     def _handle_get(self, filters):
         data = self.endpoints[self.will_call]['GET']
+        if callable(data):
+            data = data()
         self.calls.setdefault(self.will_call, []).append(('GET', filters))
         if isinstance(data, list):
             page = filters.get('page', 1)
@@ -116,7 +124,10 @@ class MockAPI(object):
 
     def _handle_patch(self, data):
         self.calls.setdefault(self.will_call, []).append(('PATCH', data))
-        return self.endpoints[self.will_call]['PATCH']
+        data = self.endpoints[self.will_call]['PATCH']
+        if callable(data):
+            data = data()
+        return data
 
     def _fmt_url(self, page):
         return 'http://testserver/?page={0}'.format(page)


### PR DESCRIPTION
This allows you to mock an endpoint with a function that raises a
`beanbag.bbexcept.BeanBagException` so you can test for PDC
failures and other fun stuff.
