### PR TITLE
Move version definition into library part not the executable

### DIFF
--- a/bin/pdc_client
+++ b/bin/pdc_client
@@ -15,9 +15,7 @@ import optparse
 import sys
 
 from beanbag import BeanBagException
-from pdc_client import PDCClient
-
-__version__ = '0.1'
+from pdc_client import PDCClient, __version__
 
 
 def debug_request(func):

--- a/pdc_client/__init__.py
+++ b/pdc_client/__init__.py
@@ -15,6 +15,8 @@ import requests_kerberos
 import warnings
 from os.path import expanduser, isfile
 
+__version__ = '0.1'
+
 from pdc_client import monkey_patch
 
 monkey_patch.monkey_patch_kerberos()


### PR DESCRIPTION
Question is - currently tagged version doesn't match. Why? 

This will be needed for next PR
