### PR TITLE
Fix release component update logging type

### DIFF
--- a/pdc_client/plugins/component.py
+++ b/pdc_client/plugins/component.py
@@ -288,7 +288,7 @@ class ReleaseComponentPlugin(PDCClientPlugin):
             data['active'] = args.active
         if data:
             self.logger.debug('Updating release component %d with data %r',
-                              release_component_id, data)
+                              int(release_component_id), data)
             self.client['release-components'][release_component_id]._ += data
         else:
             self.logger.debug('Empty data, skipping request')


### PR DESCRIPTION
release_component_id is sting at this time and logging complains when running
testsuite on F22. Partial traceback:

  File "/home/w0rm/rpmbuild/BUILD/pdc-client-0.1.9/pdc_client/plugins/component.py", line 291, in release_component_update
    release_component_id, data)
  File "/usr/lib64/python2.7/logging/**init**.py", line 1153, in debug
    self._log(DEBUG, msg, args, **kwargs)
  File "/usr/lib64/python2.7/logging/__init__.py", line 1284, in _log
    self.handle(record)
  File "/usr/lib64/python2.7/logging/__init__.py", line 1294, in handle
    self.callHandlers(record)
  File "/usr/lib64/python2.7/logging/**init**.py", line 1334, in callHandlers
    hdlr.handle(record)
  File "/usr/lib64/python2.7/logging/**init**.py", line 757, in handle
    self.emit(record)
  File "/usr/lib/python2.7/site-packages/nose/plugins/logcapture.py", line 82, in emit
    self.buffer.append(self.format(record))
  File "/usr/lib64/python2.7/logging/**init**.py", line 732, in format
    return fmt.format(record)
  File "/usr/lib64/python2.7/logging/**init**.py", line 471, in format
    record.message = record.getMessage()
  File "/usr/lib64/python2.7/logging/**init**.py", line 335, in getMessage
    msg = msg % self.args
TypeError: %d format: a number is required, not str
