### PR TITLE
PATCH on build-image-rtt-tests with build_nvr/format

### DIFF
--- a/pdc_client/plugins/build_image_rtt_tests.py
+++ b/pdc_client/plugins/build_image_rtt_tests.py
@@ -55,13 +55,8 @@ class BuildImageRttTest(PDCClientPlugin):
         if build_images_rrt:
             print_build_image_rtt_list(build_images_rrt)
 
-    def build_image_rrt_tests_info(self, args, rtt_id=None):
-        if not rtt_id:
-            rtt_id = self._get_build_image_rtt_id(args.build_nvr, args.image_format)
-        if not rtt_id:
-            self.subparsers.choices.get('info').error("This build image rtt test doesn't exist.\n")
-        args.id = rtt_id
-        build_image_rtts = self.client['build-image-rtt-tests'][rtt_id]._()
+    def build_image_rrt_tests_info(self, args):
+        build_image_rtts = self.client['build-image-rtt-tests'][args.build_nvr][args.image_format]._()
         if args.json:
             print json.dumps(build_image_rtts)
             return
@@ -73,15 +68,13 @@ class BuildImageRttTest(PDCClientPlugin):
 
     def build_image_rrt_tests_update(self, args):
         data = extract_arguments(args)
-        rtt_id = self._get_build_image_rtt_id(args.build_nvr, args.image_format)
-        if not rtt_id:
-            self.subparsers.choices.get('info').error("This build image rtt test doesn't exist.\n")
         if data:
-            self.logger.debug('Updating global component %s with data %r', rtt_id, data)
-            self.client['build-image-rtt-tests'][rtt_id]._ += data
+            self.logger.debug('Updating global component %s and %s with data %r',
+                              args.build_nvr, args.image_format, data)
+            self.client['build-image-rtt-tests'][args.build_nvr][args.image_format]._ += data
         else:
             self.logger.debug('Empty data, skipping request')
-        self.build_image_rrt_tests_info(args, rtt_id)
+        self.build_image_rrt_tests_info(args)
 
     def _get_build_image_rtt_id(self, build_nvr, image_format):
         results = self.client['build-image-rtt-tests']._(build_nvr=build_nvr, image_format=image_format)

--- a/tests/build_image_rtt_tests/tests.py
+++ b/tests/build_image_rtt_tests/tests.py
@@ -37,16 +37,16 @@ class BuildImageRttTestsTestCase(CLITestCase):
 
     def test_info(self, api):
         self._setup_build_image_rtt_tests_detail(api)
-        api.add_endpoint('build-image-rtt-tests/3', 'GET', self.detail)
+        api.add_endpoint('build-image-rtt-tests/EjaErg-1/vdi', 'GET', self.detail)
         with self.expect_output('build_image_rtt_tests.txt'):
             self.runner.run(['build-image-rtt-tests', 'info', 'EjaErg-1', 'vdi'])
-        self.assertEqual(api.calls['build-image-rtt-tests/3'],
+        self.assertEqual(api.calls['build-image-rtt-tests/EjaErg-1/vdi'],
                          [('GET', {})])
 
     def test_update_rrt_tests(self, api):
         api.add_endpoint('build-image-rtt-tests', 'GET', [self.detail])
-        api.add_endpoint('build-image-rtt-tests/3', 'GET', self.detail)
-        api.add_endpoint('build-image-rtt-tests/3', 'PATCH',
+        api.add_endpoint('build-image-rtt-tests/EjaErg-1/vdi', 'GET', self.detail)
+        api.add_endpoint('build-image-rtt-tests/EjaErg-1/vdi', 'PATCH',
                          {
                              "id": 3,
                              "build_nvr": "EjaErg-1",
@@ -56,11 +56,11 @@ class BuildImageRttTestsTestCase(CLITestCase):
         with self.expect_output('build_image_rtt_tests.txt'):
             self.runner.run(['build-image-rtt-tests', 'update',
                              '--test-result', 'passed', 'EjaErg-1', 'vdi'])
-        self.assertEqual(api.calls['build-image-rtt-tests/3'],
+        self.assertEqual(api.calls['build-image-rtt-tests/EjaErg-1/vdi'],
                          [('PATCH', {'test_result': 'passed'}), ('GET', {})])
 
     def test_detail_json(self, api):
         self._setup_build_image_rtt_tests_detail(api)
-        api.add_endpoint('build-image-rtt-tests/3', 'GET', self.detail)
+        api.add_endpoint('build-image-rtt-tests/EjaErg-1/vdi', 'GET', self.detail)
         with self.expect_output('detail.json', parse_json=True):
             self.runner.run(['--json', 'build-image-rtt-tests', 'info', 'EjaErg-1', 'vdi'])


### PR DESCRIPTION
As pdc server have supported the PATCH on build-image-rtt-tests with
build_nvr/format instead od ID, the pdc client also need to
update.

JIRA: PDC-1269
