### PR TITLE
Modify compose-tree-locations in client because API url changed.

### DIFF
--- a/pdc_client/plugins/compose_tree_locations.py
+++ b/pdc_client/plugins/compose_tree_locations.py
@@ -53,6 +53,7 @@ class ComposeTreeLocationsPlugin(PDCClientPlugin):
         parser.add_argument('variant_uid', metavar='VARIANT_UID')
         parser.add_argument('arch', metavar='ARCH')
         parser.add_argument('location', metavar='LOCATION')
+        parser.add_argument('scheme', metavar='SCHEME')
 
     def add_compose_tree_location_arguments(self, parser, required=False):
         required_args = {
@@ -108,13 +109,13 @@ class ComposeTreeLocationsPlugin(PDCClientPlugin):
 
     def compose_tree_location_info(self, args):
         compose_tree_location_info =\
-            self.client['compose-tree-locations'][args.compose_id][args.variant_uid][args.arch][args.location]._()
+            self.client['compose-tree-locations'][args.compose_id][args.variant_uid][args.arch][args.location][args.scheme]._()
         self._display_compose_tree_location_info(args, compose_tree_location_info)
 
     def compose_tree_location_update(self, args):
         data = extract_arguments(args)
         compose_tree_location_info =\
-            self.client['compose-tree-locations'][args.compose_id][args.variant_uid][args.arch][args.location]._('PATCH', data)
+            self.client['compose-tree-locations'][args.compose_id][args.variant_uid][args.arch][args.location][args.scheme]._('PATCH', data)
         self._display_compose_tree_location_info(args, compose_tree_location_info)
 
     def compose_tree_location_create(self, args):
@@ -124,7 +125,7 @@ class ComposeTreeLocationsPlugin(PDCClientPlugin):
 
     def compose_tree_location_delete(self, args):
         data = extract_arguments(args)
-        self.client['compose-tree-locations'][args.compose_id][args.variant_uid][args.arch][args.location]\
+        self.client['compose-tree-locations'][args.compose_id][args.variant_uid][args.arch][args.location][args.scheme]\
             ._("DELETE", data)
 
 PLUGIN_CLASSES = [ComposeTreeLocationsPlugin]

--- a/tests/compose_tree_locations/tests.py
+++ b/tests/compose_tree_locations/tests.py
@@ -41,14 +41,14 @@ class ComposeTreeLocationsTestCase(CLITestCase):
                "scheme": "http",
                "synced_content": "debug",
                "url": "http://example.com"}
-        api.add_endpoint('compose-tree-locations/Awesome-product-7.0-0/Server/x86_64/NAY',
+        api.add_endpoint('compose-tree-locations/Awesome-product-7.0-0/Server/x86_64/NAY/https',
                          'GET', obj)
         # PATCH test result to passed
         obj_update = deepcopy(obj)
         obj_update["scheme"] = "https"
         obj_update["url"] = "https://example1.com"
         obj_update["synced_content"] = "source"
-        api.add_endpoint('compose-tree-locations/Awesome-product-7.0-0/Server/x86_64/NAY',
+        api.add_endpoint('compose-tree-locations/Awesome-product-7.0-0/Server/x86_64/NAY/https',
                          'PATCH', obj_update)
 
     def test_list(self, api):
@@ -63,27 +63,28 @@ class ComposeTreeLocationsTestCase(CLITestCase):
         self._setup_detail(api)
         with self.expect_output('detail.txt'):
             self.runner.run(['compose-tree-locations', 'info', 'Awesome-product-7.0-0', 'Server',
-                             'x86_64', 'NAY'])
+                             'x86_64', 'NAY', 'https'])
         self.assertEqual(
-            api.calls['compose-tree-locations/Awesome-product-7.0-0/Server/x86_64/NAY'],
+            api.calls['compose-tree-locations/Awesome-product-7.0-0/Server/x86_64/NAY/https'],
             [('GET', {})])
 
     def test_info_json(self, api):
         self._setup_detail(api)
         with self.expect_output('detail.json', parse_json=True):
             self.runner.run(['--json', 'compose-tree-locations', 'info', 'Awesome-product-7.0-0', 'Server',
-                             'x86_64', 'NAY'])
+                             'x86_64', 'NAY', 'https'])
         self.assertEqual(
-            api.calls['compose-tree-locations/Awesome-product-7.0-0/Server/x86_64/NAY'],
+            api.calls['compose-tree-locations/Awesome-product-7.0-0/Server/x86_64/NAY/https'],
             [('GET', {})])
 
     def test_update(self, api):
         self._setup_detail(api)
         with self.expect_output('detail_for_patch.txt'):
             self.runner.run(['compose-tree-locations', 'update', 'Awesome-product-7.0-0', 'Server', 'x86_64', 'NAY',
-                             '--scheme', 'https', '--synced-content', 'source', '--url', 'https://example1.com'])
-        self.assertEqual(api.calls, {'compose-tree-locations/Awesome-product-7.0-0/Server/x86_64/NAY':
-                                     [('PATCH', {'scheme': 'https',
+                             'https', '--scheme', 'http', '--synced-content', 'source',
+                             '--url', 'https://example1.com'])
+        self.assertEqual(api.calls, {'compose-tree-locations/Awesome-product-7.0-0/Server/x86_64/NAY/https':
+                                     [('PATCH', {'scheme': 'http',
                                                  'synced_content': ['source'],
                                                  'url': 'https://example1.com'})]})
 
@@ -128,9 +129,10 @@ class ComposeTreeLocationsTestCase(CLITestCase):
                                                                           'url': 'http://example.com'})]})
 
     def test_delete(self, api):
-        api.add_endpoint('compose-tree-locations/Awesome-product-7.0-0/Server/x86_64/NAY',
+        api.add_endpoint('compose-tree-locations/Awesome-product-7.0-0/Server/x86_64/NAY/https',
                          'DELETE', None)
         with self.expect_output('empty.txt'):
-            self.runner.run(['compose-tree-locations', 'delete', 'Awesome-product-7.0-0', 'Server', 'x86_64', 'NAY'])
-        self.assertEqual(api.calls, {'compose-tree-locations/Awesome-product-7.0-0/Server/x86_64/NAY':
+            self.runner.run(['compose-tree-locations', 'delete', 'Awesome-product-7.0-0', 'Server', 'x86_64', 'NAY',
+                             'https'])
+        self.assertEqual(api.calls, {'compose-tree-locations/Awesome-product-7.0-0/Server/x86_64/NAY/https':
                                      [('DELETE', {})]})


### PR DESCRIPTION
Because scheme is added to compose-tree-locations API url,
pdc client is changed correspondingly in info/update/delete.

JIRA: PDC-1445
