### PR TITLE
Change configuration files for pdc-client

### DIFF
--- a/pdc-client.spec
+++ b/pdc-client.spec
@@ -135,7 +135,7 @@ mkdir -p %{buildroot}/%{_sysconfdir}/bash_completion.d/
 cp pdc.bash %{buildroot}/%{_sysconfdir}/bash_completion.d/
 
 mkdir -p %{buildroot}/%{_sysconfdir}/pdc
-cat > %{buildroot}/%{_sysconfdir}/pdc/client_config.json << EOF
+cat > %{buildroot}/%{_sysconfdir}/pdc.d/fedora.json << EOF
 {
     "dev": {
         "host": "https://pdc.fedoraproject.org/rest_api/v1/",
@@ -151,7 +151,7 @@ EOF
 %{_mandir}/man1/pdc_client.1*
 %{_sysconfdir}/bash_completion.d
 %dir %{_sysconfdir}/pdc
-%config(noreplace) %{_sysconfdir}/pdc/client_config.json
+%config(noreplace) %{_sysconfdir}/pdc.d/fedora.json
 %{_bindir}/pdc
 %{_bindir}/pdc_client
 


### PR DESCRIPTION
The configuration for client should be in a dropdir (/etc/pdc.d/)
so that multiple config files can be installed at the same time.
1. Load a config dict from each file.
2. If two dicts contain the same key, report an error (the error
message should include the key and all file names defining it)
3. Merge all these dicts.
4. Continue as before: load user config file and apply changes from it

JIRA: PDC-1563
