### PR TITLE
Handle page_size in mocked API calls.

### DIFF
--- a/pdc_client/test_helpers.py
+++ b/pdc_client/test_helpers.py
@@ -129,9 +129,9 @@ else:
             if callable(data):
                 data = data()
             self.calls.setdefault(self.will_call, []).append(('GET', filters))
-            if isinstance(data, list):
+            page_size = filters.get('page_size', 20)
+            if isinstance(data, list) and page_size > 0:
                 page = filters.get('page', 1)
-                page_size = 20
                 pages = int(math.ceil(float(len(data)) / page_size))
                 data = data[(page - 1) * page_size:(page - 1) * page_size + page_size]
                 return {

--- a/pdc_client/test_helpers_py3.py
+++ b/pdc_client/test_helpers_py3.py
@@ -123,9 +123,9 @@ class MockAPI(object):
         if callable(data):
             data = data()
         self.calls.setdefault(self.will_call, []).append(('GET', filters))
-        if isinstance(data, list):
+        page_size = filters.get('page_size', 20)
+        if isinstance(data, list) and page_size > 0:
             page = filters.get('page', 1)
-            page_size = 20
             pages = int(math.ceil(float(len(data)) / page_size))
             data = data[(page - 1) * page_size:(page - 1) * page_size + page_size]
             return {


### PR DESCRIPTION
This is important for non-positive values of page_size, returning lists
that aren't wrapped in paged dicts.

Signed-off-by: Nils Philippsen nils@redhat.com
