### PR TITLE
Python 3 build

### DIFF
--- a/pdc-client.spec
+++ b/pdc-client.spec
@@ -5,12 +5,9 @@
 %{!?python2_sitelib: %global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print (get_python_lib())")}
 %endif
 
-# upstream has no support now, some dependencies are missing
-%global with_python3 0
-
 Name:           pdc-client
 Version:        1.1.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Console client for interacting with Product Definition Center
 Group:          Development/Libraries
 License:        MIT
@@ -125,7 +122,7 @@ popd
 %install
 %py2_install
 %if 0%{?with_python3}
-py3_install
+%py3_install
 %endif # with_python3
 
 mkdir -p %{buildroot}/%{_mandir}/man1
@@ -176,6 +173,9 @@ EOF
 
 
 %changelog
+* Fri Aug 12 2016 Jiri Popelka <jpopelka@redhat.com> - 1.1.0-2
+- Python3 build
+
 * Sun Aug 07 2016 bliu <bliu@redhat.com> 1.1.0-1
 - When page_size <= 0; the pagination will be disabled. (bliu@redhat.com)
 - Handle page_size in mocked API calls. (nils@redhat.com)

--- a/pdc_client/__init__.py
+++ b/pdc_client/__init__.py
@@ -193,9 +193,9 @@ class PDCClient(object):
         if self.page_size is not None:
             kwargs['page_size'] = self.page_size
 
-        if self.page_size <= 0 and self.page_size is not None:
-            # If page_size <= 0, pagination will be disable.
-            return res(**kwargs)
+            if self.page_size <= 0:
+                # If page_size <= 0, pagination will be disable.
+                return res(**kwargs)
 
         def worker():
             kwargs['page'] = 1


### PR DESCRIPTION
As stated in https://bugzilla.redhat.com/show_bug.cgi?id=1352472 all dependencies have been ported so you can enable Python 3 build in spec file.

I've tried to build and briefly use `python3-pdc-client` and it looks OK to me.
