### PR TITLE
Create a new plugin of compose-full-import

### DIFF
--- a/pdc_client/plugins/compose_full_import.py
+++ b/pdc_client/plugins/compose_full_import.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2015 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+
+from __future__ import print_function
+
+import json
+import sys
+import os
+
+from pdc_client.plugin_helpers import PDCClientPlugin, add_create_update_args, extract_arguments
+
+
+class ComposeFullImportPlugin(PDCClientPlugin):
+    def register(self):
+        self.set_command('compose-full-import')
+        create_parser = self.add_action('create', help='Import RPMs, images, create new compose and set compose tree location',
+                                        description='The composeinfo, rpm_manifest and image_manifest values ' +
+                                                    'should be actual JSON representation of composeinfo, ' +
+                                                    'rpm manifest and image manifest, as stored in ' +
+                                                    'composeinfo.json, rpm-manifest.json and image-manifest.json files. ' +
+                                                    'location, url, scheme are used to set compose tree location.')
+        self.add_compose_full_import_arguments(create_parser, required=True)
+        create_parser.set_defaults(func=self.compose_full_import_create)
+
+    def add_compose_full_import_arguments(self, parser, required=False):
+        required_args = {
+            'release_id': {'type': str},
+            'composeinfo': {},
+            'rpm_manifest': {},
+            'image_manifest': {},
+            'location': {'type': str},
+            'url': {'type': str},
+            'scheme': {'type': str}}
+        optional_args = {}
+        add_create_update_args(parser, required_args, optional_args, required)
+
+    def _display_compose_import_info(self, args, compose_import_info):
+        if args.json:
+            print(json.dumps(compose_import_info))
+            return
+        fmt = '{0:20} {1}'
+        print(fmt.format('Compose', compose_import_info['compose']))
+        print(fmt.format('Imported Images', compose_import_info['imported images']))
+        print(fmt.format('Imported Rpms', compose_import_info['imported rpms']))
+        print(fmt.format('Set_locations', compose_import_info['set_locations']))
+
+    def compose_full_import_create(self, args):
+        parser_args = self._get_value_from_json(args)
+        data = extract_arguments(parser_args)
+        response = self.client['rpc/compose-full-import']._(data)
+        self._display_compose_import_info(parser_args, response)
+
+    def _get_value_from_json(self, args):
+        args.data__composeinfo = self._read_json_file(args.data__composeinfo)
+        args.data__image_manifest = self._read_json_file(args.data__image_manifest)
+        args.data__rpm_manifest = self._read_json_file(args.data__rpm_manifest)
+        return args
+
+    def _read_json_file(self, path):
+        if os.path.isfile(path):
+            with open(path, 'r') as f:
+                data = json.load(f)
+        else:
+            print("Error: '%s' file can't find, please verify it" % path)
+            sys.exit(1)
+        return data
+
+
+PLUGIN_CLASSES = [ComposeFullImportPlugin]

--- a/pdc_client/runner.py
+++ b/pdc_client/runner.py
@@ -47,6 +47,7 @@ DEFAULT_PLUGINS = [
     'component.py',
     'compose_image_rtt_tests.py',
     'compose.py',
+    'compose_full_import.py',
     'compose_tree_locations.py',
     'contact.py',
     'image.py',

--- a/pdc_client/test_helpers.py
+++ b/pdc_client/test_helpers.py
@@ -191,6 +191,9 @@ else:
             with open(os.path.join(self._data_dir, file), 'r') as f:
                 return f.read()
 
+        def data_file_abspath(self, file):
+            return os.path.join(self._data_dir, file)
+
         @contextlib.contextmanager
         def expect_output(self, file, parse_json=False):
             """Expect contents of the with statement to print contents of file.

--- a/pdc_client/test_helpers_py3.py
+++ b/pdc_client/test_helpers_py3.py
@@ -186,6 +186,9 @@ class CLITestCase(unittest.TestCase, metaclass=CLIMetaClass):
         with open(os.path.join(self._data_dir, file), 'r') as f:
             return f.read()
 
+    def data_file_abspath(self, file):
+        return os.path.join(self._data_dir, file)
+
     @contextlib.contextmanager
     def expect_output(self, file, parse_json=False):
         """Expect contents of the with statement to print contents of file.

--- a/tests/compose_full_import/data/composeinfo.json
+++ b/tests/compose_full_import/data/composeinfo.json
@@ -1,0 +1,9 @@
+{
+    "arch": "x86_64",
+    "compose": "Awesome-product-7.0-0",
+    "variant": "Server",
+    "location": "NAY",
+    "scheme": "http",
+    "synced_content": "debug",
+    "url": "http://example.com"
+ }

--- a/tests/compose_full_import/data/detail.txt
+++ b/tests/compose_full_import/data/detail.txt
@@ -1,0 +1,4 @@
+Compose              Awesome-product-7.0-0
+Imported Images      1
+Imported Rpms        1
+Set_locations        1

--- a/tests/compose_full_import/data/image_manifest.json
+++ b/tests/compose_full_import/data/image_manifest.json
@@ -1,0 +1,20 @@
+{
+  "composes": [
+    "compose-1"
+  ],
+  "sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+  "sha1": "2222222222222222222222222222222222222222",
+  "md5": "11111111111111111111111111111111",
+  "implant_md5": "00000000000000000000000000000000",
+  "volume_id": "VolumeID",
+  "bootable": true,
+  "file_name": "unique_image.iso",
+  "image_type": "dvd",
+  "image_format": "iso",
+  "arch": "x86_64",
+  "disc_number": 1,
+  "disc_count": 1,
+  "mtime": 1442923687,
+  "size": 123456789,
+  "subvariant": "subvariant_1"
+}

--- a/tests/compose_full_import/data/rpm_manifest.json
+++ b/tests/compose_full_import/data/rpm_manifest.json
@@ -1,0 +1,22 @@
+{
+    "id": 1,
+    "name": "bash",
+    "epoch": 0,
+    "version": "4.3.42",
+    "release": 1,
+    "arch": "x86_64",
+    "srpm_name": "bash",
+    "srpm_nevra": "bash-4.3.42-1.src",
+    "filename": "bash-0:4.3.42-1.x86_64.rpm",
+    "linked_composes": ["compose-1"],
+    "linked_releases": ["release-1"],
+    "dependencies": {
+            "requires": ["glibc > 0"],
+            "obsoletes": [],
+            "recommends": [],
+            "suggests": [],
+            "conflicts": [],
+            "provides": []
+        }
+}
+

--- a/tests/compose_full_import/tests.py
+++ b/tests/compose_full_import/tests.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2015 Red Hat
+# Licensed under The MIT License (MIT)
+# http://opensource.org/licenses/MIT
+#
+from pdc_client.test_helpers import CLITestCase
+from pdc_client.runner import Runner
+
+
+class ComposeFullImportTestCase(CLITestCase):
+    def setUp(self):
+        self.runner = Runner()
+        self.runner.setup()
+
+    def _setup_detail(self, api):
+        obj = {'set_locations': 1,
+               'compose': 'Awesome-product-7.0-0',
+               'imported images': 1,
+               'imported rpms': 1}
+
+        api.add_endpoint('rpc/compose-full-import',
+                         'POST', obj)
+
+    def test_create(self, api):
+        self._setup_detail(api)
+        composeinfo_path = self.data_file_abspath('composeinfo.json')
+        image_manifest_path = self.data_file_abspath('image_manifest.json')
+        rpm_manifest_path = self.data_file_abspath('rpm_manifest.json')
+
+        with self.expect_output('detail.txt'):
+            self.runner.run(['compose-full-import', 'create',
+                             '--composeinfo', composeinfo_path,
+                             '--image-manifest', image_manifest_path,
+                             '--rpm-manifest', rpm_manifest_path,
+                             '--release-id', 'rhel-7.3',
+                             '--url', 'abc.com',
+                             '--location', 'nay',
+                             '--scheme', 'http'])


### PR DESCRIPTION
The plugin of compose-full-import is mapping to the
rpc/compose-full-import resource; which use to import a compose.

JIRA: PDC-1736
