### PR TITLE
More flexible SSL certificate verification configuration

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,9 +31,9 @@ Other possible keys are:
     If specified, this token will be used for authentication. The client
     will not try to obtain any token from the server.
 
-* `insecure`
+* `ssl_verify`
 
-    If set to `true`, server certificate will not be validated.
+    If set to `false`, server certificate will not be validated. See [Python requests documentation](http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification) for other possible values.
 
 * `develop`
 

--- a/pdc-client.spec
+++ b/pdc-client.spec
@@ -147,7 +147,7 @@ cat > %{buildroot}/%{_sysconfdir}/pdc.d/fedora.json << EOF
     "fedora": {
         "host": "https://pdc.fedoraproject.org/rest_api/v1/",
         "develop": false,
-        "insecure": false
+        "ssl-verify": true
     }
 }
 EOF

--- a/pdc_client/__init__.py
+++ b/pdc_client/__init__.py
@@ -17,7 +17,6 @@ from subprocess import Popen, PIPE
 import beanbag
 import requests
 import requests_kerberos
-import warnings
 
 GLOBAL_CONFIG_DIR = '/etc/pdc.d/'
 USER_SPECIFIC_CONFIG_FILE = expanduser('~/.config/pdc/client_config.json')

--- a/pdc_client/__init__.py
+++ b/pdc_client/__init__.py
@@ -21,6 +21,7 @@ import requests_kerberos
 GLOBAL_CONFIG_DIR = '/etc/pdc.d/'
 USER_SPECIFIC_CONFIG_FILE = expanduser('~/.config/pdc/client_config.json')
 CONFIG_URL_KEY_NAME = 'host'
+CONFIG_INSECURE_KEY_NAME = 'insecure'
 CONFIG_SSL_VERIFY_KEY_NAME = 'ssl-verify'
 CONFIG_DEVELOP_KEY_NAME = 'develop'
 CONFIG_TOKEN_KEY_NAME = 'token'
@@ -120,6 +121,11 @@ class PDCClient(object):
                 print("'%s' must be specified in configuration file." % CONFIG_URL_KEY_NAME)
                 sys.exit(1)
             ssl_verify = config.get(CONFIG_SSL_VERIFY_KEY_NAME, ssl_verify)
+            insecure = config.get(CONFIG_SSL_VERIFY_KEY_NAME)
+            if insecure is not None:
+                sys.stderr.write("Warning: '%s' option is deprecated; please use '%s' instead" % (
+                    CONFIG_INSECURE_KEY_NAME, CONFIG_SSL_VERIFY_KEY_NAME))
+                ssl_verify = not insecure
             develop = config.get(CONFIG_DEVELOP_KEY_NAME, develop)
             token = config.get(CONFIG_TOKEN_KEY_NAME, token)
 


### PR DESCRIPTION
The Python `requests` library has more flexible configuration for SSL certificate verification than the PDC client currently permits. This patch removes the `insecure` configuration option in favor of `ssl_verify` (in the class constructor keyword arguments) and `ssl-verify` (in the JSON configuration format). The value is passed through directly to the `requests` session.

This is particularly useful for validation against a specific certificate, which can be specified as a path. See the [`requests` documentation](http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification) for more information.