### PR TITLE
Add the SSL and remove the Warning Info

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -97,6 +97,10 @@ run this in your terminal (assuming pdc is somewhere on path).
 
 or put `pdc.bash` to `/etc/bash_completion.d/`.
 
+### `Info`
+
+The client command line parameters take precedence over configuration file values.
+
 ## Python API
 
 When writing a client code interfacing with PDC server, you might find

--- a/bin/pdc_client
+++ b/bin/pdc_client
@@ -14,6 +14,7 @@ except ImportError:
 import optparse
 import sys
 
+import requests
 from beanbag import BeanBagException
 import pdc_client
 from pdc_client import PDCClient
@@ -119,6 +120,11 @@ def load_data(options):
 if __name__ == "__main__":
     parser = optparse.OptionParser(version=__version__)
     parser.add_option("-s", "--server", help="PDC instance url or shortcut.")
+    parser.add_option("-k", "--insecure", action="store_true",
+                      help="Disable SSL certificate verification")
+    # ca-cert corresponds to requests session verify attribute:
+    # http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
+    parser.add_option("--ca-cert", help="Path to CA certificate file or directory")
     parser.add_option("-x", "--request", default="GET", help="Request method.")
     parser.add_option("-r", "--resource",
                       help=("Resource name.\n" +
@@ -163,7 +169,11 @@ if __name__ == "__main__":
                 data[key] = ''
 
     try:
-        client = PDCClient(options.server)
+        ssl_verify = options.ca_cert or not options.insecure
+        if options.insecure:
+            requests.packages.urllib3.disable_warnings(
+                requests.packages.urllib3.exceptions.InsecureRequestWarning)
+        client = PDCClient(options.server, ssl_verify=ssl_verify)
         if options.comment:
             client.set_comment(options.comment)
     except BeanBagException as e:

--- a/pdc_client/__init__.py
+++ b/pdc_client/__init__.py
@@ -97,7 +97,7 @@ class PDCClient(object):
     connections. The authentication token is automatically retrieved (if
     needed).
     """
-    def __init__(self, server, token=None, develop=False, ssl_verify=True, page_size=None):
+    def __init__(self, server, token=None, develop=False, ssl_verify=None, page_size=None):
         """Create new client instance.
 
         Once the class is instantiated, use it as you would use a regular
@@ -120,10 +120,10 @@ class PDCClient(object):
             except KeyError:
                 print("'%s' must be specified in configuration file." % CONFIG_URL_KEY_NAME)
                 sys.exit(1)
-            ssl_verify = config.get(CONFIG_SSL_VERIFY_KEY_NAME, ssl_verify)
+            ssl_verify = config.get(CONFIG_SSL_VERIFY_KEY_NAME) if ssl_verify is None else ssl_verify
             insecure = config.get(CONFIG_INSECURE_KEY_NAME)
             if insecure is not None:
-                sys.stderr.write("Warning: '%s' option is deprecated; please use '%s' instead" % (
+                sys.stderr.write("Warning: '%s' option is deprecated; please use '%s' instead\n" % (
                     CONFIG_INSECURE_KEY_NAME, CONFIG_SSL_VERIFY_KEY_NAME))
                 ssl_verify = not insecure
             develop = config.get(CONFIG_DEVELOP_KEY_NAME, develop)

--- a/pdc_client/runner.py
+++ b/pdc_client/runner.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 import sys
 import argparse
 import beanbag
+import requests
 import os
 import os.path
 import logging
@@ -125,6 +126,13 @@ class Runner(object):
         self.parser = argparse.ArgumentParser(description='PDC Client')
         self.parser.add_argument('-s', '--server', default='stage',
                                  help='API URL or shortcut from config file')
+
+        self.parser.add_argument('-k', '--insecure', action='store_true',
+                                 help='Disable SSL certificate verification')
+        # ca-cert corresponds to requests session verify attribute:
+        # http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
+        self.parser.add_argument("--ca-cert", help="Path to CA certificate file or directory")
+
         self.parser.add_argument('--debug', action='store_true', help=argparse.SUPPRESS)
         self.parser.add_argument('--json', action='store_true',
                                  help='display output as JSON')
@@ -143,7 +151,12 @@ class Runner(object):
 
     def run(self, args=None):
         self.args = self.parser.parse_args(args=args)
-        self.client = pdc_client.PDCClient(self.args.server, page_size=self.args.page_size)
+        ssl_verify = self.args.ca_cert or not self.args.insecure
+        if self.args.insecure:
+            requests.packages.urllib3.disable_warnings(
+                requests.packages.urllib3.exceptions.InsecureRequestWarning)
+        self.client = pdc_client.PDCClient(self.args.server, page_size=self.args.page_size,
+                                           ssl_verify=ssl_verify)
         try:
             self.args.func(self.args)
         except beanbag.BeanBagException as exc:


### PR DESCRIPTION
Adds two options to both pdc and pdc_client:
-k/--insecure: disable verification (ssl_verify = False)
--ca-cert: path to CA certificate (ssl_verify = '/path/to/CA.crt')

When "insecure" behavior is desired, urllib warnings are muted.

JIRA: PDC-1802