### PR TITLE
Fix SSL command line options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.py[co]
 *.swp
 .tito/copr_user.conf
+/pdc_client.egg-info

--- a/bin/pdc_client
+++ b/bin/pdc_client
@@ -11,7 +11,7 @@ try:
 except ImportError:
     import simplejson as json
 
-import optparse
+import argparse
 import sys
 
 import requests
@@ -20,6 +20,7 @@ import pdc_client
 from pdc_client import PDCClient
 
 __version__ = pdc_client.get_version()
+
 
 def debug_request(func):
     def wrap(*args, **kwargs):
@@ -118,47 +119,39 @@ def load_data(options):
 
 
 if __name__ == "__main__":
-    parser = optparse.OptionParser(version=__version__)
-    parser.add_option("-s", "--server", help="PDC instance url or shortcut.")
-    parser.add_option("-k", "--insecure", action="store_true",
-                      help="Disable SSL certificate verification")
+    parser = argparse.ArgumentParser(version=__version__)
+    parser.add_argument("-s", "--server", help="PDC instance url or shortcut.")
+
+    ssl_group = parser.add_mutually_exclusive_group()
+    ssl_group.add_argument("-k", "--insecure", action="store_true",
+                           help="Disable SSL certificate verification")
     # ca-cert corresponds to requests session verify attribute:
     # http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
-    parser.add_option("--ca-cert", help="Path to CA certificate file or directory")
-    parser.add_option("-x", "--request", default="GET", help="Request method.")
-    parser.add_option("-r", "--resource",
-                      help=("Resource name.\n" +
-                            "NOTE: All available resources can be got by a request " +
-                            "to the API Root. Since API Root does not belong to any " +
-                            "resources, while requesting, please omit the `-r` option.\n" +
-                            "The response of API Root request is a dict with resource names " +
-                            "as keys and resource URIs as values."),
-                      default="")
-    parser.add_option("-d", "--data", help="Request data to server.")
-    parser.add_option("-f", "--file",
-                      help="File to load request data from (or - for stdin).")
-    parser.add_option("-t", "--traceback",
-                      help="Show the traceback when an error occurs",
-                      action="store_true", default=False)
-    parser.add_option("--debug", help="Show request headers and path for "
-                                      "debugging.",
-                      action="store_true", default=False)
-    parser.add_option("-c", "--comment", help="Reasons for the PDC change.")
-    options, args = parser.parse_args()
+    ssl_group.add_argument("--ca-cert", help="Path to CA certificate file or directory")
 
-    if len(args):
-        print("Can not parse the positional arguments: %s" % ", ".join(args))
-        parser.print_help()
-        sys.exit(1)
+    parser.add_argument("-x", "--request", default="GET", help="Request method.")
+    parser.add_argument("-r", "--resource",
+                        help=("Resource name.\n" +
+                              "NOTE: All available resources can be got by a request " +
+                              "to the API Root. Since API Root does not belong to any " +
+                              "resources, while requesting, please omit the `-r` option.\n" +
+                              "The response of API Root request is a dict with resource names " +
+                              "as keys and resource URIs as values."),
+                        default="")
 
-    if not options.server:
-        print("Error: -s is required.\n")
-        parser.print_help()
-        sys.exit(1)
+    data_group = parser.add_mutually_exclusive_group()
+    data_group.add_argument("-d", "--data", help="Request data to server.")
+    data_group.add_argument("-f", "--file",
+                            help="File to load request data from (or - for stdin).")
 
-    if options.data and options.file:
-        print("Error: can not load data from file and command line at the same time.")
-        sys.exit(1)
+    parser.add_argument("-t", "--traceback",
+                        help="Show the traceback when an error occurs",
+                        action="store_true", default=False)
+    parser.add_argument("--debug", help="Show request headers and path for "
+                                        "debugging.",
+                        action="store_true", default=False)
+    parser.add_argument("-c", "--comment", help="Reasons for the PDC change.")
+    options = parser.parse_args()
 
     data = load_data(options)
 
@@ -169,11 +162,15 @@ if __name__ == "__main__":
                 data[key] = ''
 
     try:
-        ca_cert_or_insecure = options.ca_cert or options.insecure
         if options.insecure:
             requests.packages.urllib3.disable_warnings(
                 requests.packages.urllib3.exceptions.InsecureRequestWarning)
-        client = PDCClient(options.server, ca_cert_or_insecure=ca_cert_or_insecure)
+            ssl_verify = False
+        elif options.ca_cert:
+            ssl_verify = options.ca_cert
+        else:
+            ssl_verify = True
+        client = PDCClient(options.server, ssl_verify=ssl_verify)
         if options.comment:
             client.set_comment(options.comment)
     except BeanBagException as e:

--- a/pdc_client/__init__.py
+++ b/pdc_client/__init__.py
@@ -97,7 +97,7 @@ class PDCClient(object):
     connections. The authentication token is automatically retrieved (if
     needed).
     """
-    def __init__(self, server, token=None, develop=False, ca_cert_or_insecure=None, page_size=None):
+    def __init__(self, server, token=None, develop=False, ssl_verify=None, page_size=None):
         """Create new client instance.
 
         Once the class is instantiated, use it as you would use a regular
@@ -106,44 +106,43 @@ class PDCClient(object):
 
         :param server:     server API url or server name from configuration
         :paramtype server: string
-        :param ca_cert_or_insecure: it's from command line，value with the/path/to/CA/file or True/None.
+        :param ssl_verify: True for validating SSL certificates with system CA
+                           store; False for no validation; path to CA file or
+                           directory to use for validation otherwise
         """
         self.page_size = page_size
         if not server:
             raise TypeError('Server must be specified')
         self.session = requests.Session()
         config = read_config_file(server)
-        url = server
 
+        # Command line must *always* override configuration
         if config:
             try:
                 url = config[CONFIG_URL_KEY_NAME]
             except KeyError:
-                print("'%s' must be specified in configuration file." % CONFIG_URL_KEY_NAME)
+                sys.stderr.write("'{}' must be specified in configuration for '{}'".format(
+                    CONFIG_URL_KEY_NAME, server))
                 sys.exit(1)
-            if ca_cert_or_insecure is None:
-                # In client command, it's priority to use the optional parameters form command line,
-                # and then use the optional parameters which gotten from the config file.
-                ssl_verify = config.get(CONFIG_SSL_VERIFY_KEY_NAME)
+
+            if ssl_verify is None:
+                cfg_ssl_verify = config.get(CONFIG_SSL_VERIFY_KEY_NAME)
                 insecure = config.get(CONFIG_INSECURE_KEY_NAME)
-                if ssl_verify == insecure:
-                    # Give a warning if ssl_verify == insecure in config file
-                    print("In config file, the values of ssl_verify and insecure can't be the same")
-                    sys.exit(1)
                 if insecure is not None:
-                    sys.stderr.write("Warning: '%s' option is deprecated; please use '%s' instead\n" % (
-                        CONFIG_INSECURE_KEY_NAME, CONFIG_SSL_VERIFY_KEY_NAME))
-                    if insecure:
-                        ssl_verify = not insecure
-                    else:
-                        # The value of ssl_verify is the path to CA file or not insecure.
-                        ssl_verify = ssl_verify or not insecure
-            elif ca_cert_or_insecure is True:
-                ssl_verify = False
-            else:
-                ssl_verify = ca_cert_or_insecure
-            develop = config.get(CONFIG_DEVELOP_KEY_NAME, develop)
-            token = config.get(CONFIG_TOKEN_KEY_NAME, token)
+                    sys.stderr.write("Warning: '{}' option is deprecated; please use '{}' "
+                                     "instead\n".format(
+                                         CONFIG_INSECURE_KEY_NAME, CONFIG_SSL_VERIFY_KEY_NAME))
+                    ssl_verify = not insecure
+                if cfg_ssl_verify is not None:
+                    ssl_verify = cfg_ssl_verify
+            if develop is None:
+                develop = config.get(CONFIG_DEVELOP_KEY_NAME, develop)
+            if token is None:
+                token = config.get(CONFIG_TOKEN_KEY_NAME, token)
+        else:
+            url = server
+            if ssl_verify is None:
+                ssl_verify = True
 
         self.session.verify = ssl_verify
 

--- a/pdc_client/runner.py
+++ b/pdc_client/runner.py
@@ -159,7 +159,7 @@ class Runner(object):
         elif self.args.ca_cert:
             ssl_verify = self.args.ca_cert
         else:
-            ssl_verify = True
+            ssl_verify = None
         self.client = pdc_client.PDCClient(self.args.server, page_size=self.args.page_size, ssl_verify=ssl_verify)
         try:
             self.args.func(self.args)

--- a/pdc_client/runner.py
+++ b/pdc_client/runner.py
@@ -127,11 +127,12 @@ class Runner(object):
         self.parser.add_argument('-s', '--server', default='stage',
                                  help='API URL or shortcut from config file')
 
-        self.parser.add_argument('-k', '--insecure', action='store_true',
-                                 help='Disable SSL certificate verification')
+        ssl_group = self.parser.add_mutually_exclusive_group()
+        ssl_group.add_argument('-k', '--insecure', action='store_true',
+                               help='Disable SSL certificate verification')
         # ca-cert corresponds to requests session verify attribute:
         # http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
-        self.parser.add_argument("--ca-cert", help="Path to CA certificate file or directory")
+        ssl_group.add_argument("--ca-cert", help="Path to CA certificate file or directory")
 
         self.parser.add_argument('--debug', action='store_true', help=argparse.SUPPRESS)
         self.parser.add_argument('--json', action='store_true',
@@ -151,12 +152,15 @@ class Runner(object):
 
     def run(self, args=None):
         self.args = self.parser.parse_args(args=args)
-        ca_cert_or_insecure = self.args.ca_cert or self.args.insecure
         if self.args.insecure:
             requests.packages.urllib3.disable_warnings(
                 requests.packages.urllib3.exceptions.InsecureRequestWarning)
-        self.client = pdc_client.PDCClient(self.args.server, page_size=self.args.page_size,
-                                           ca_cert_or_insecure=ca_cert_or_insecure)
+            ssl_verify = False
+        elif self.args.ca_cert:
+            ssl_verify = self.args.ca_cert
+        else:
+            ssl_verify = True
+        self.client = pdc_client.PDCClient(self.args.server, page_size=self.args.page_size, ssl_verify=ssl_verify)
         try:
             self.args.func(self.args)
         except beanbag.BeanBagException as exc:


### PR DESCRIPTION
The behavior of `-k`/`--insecure` and `--ca-cert` is incorrect with no
configuration. The concept of "insecure" should also be restricted to
the command line parser; the client object should only know the value to
hand off to `requests`.

This patch corrects this issue, as well as another issue where command
line arguments would not override configuration values. The basic client
(`pdc_client` script) has been switched from `OptionParser` to
`ArgumentParser` to simplify and keep synchronized with the rich client.