### PR TITLE
Configuration fixes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,7 +31,7 @@ Other possible keys are:
     If specified, this token will be used for authentication. The client
     will not try to obtain any token from the server.
 
-* `ssl_verify`
+* `ssl-verify`
 
     If set to `false`, server certificate will not be validated. See [Python requests documentation](http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification) for other possible values.
 
@@ -57,7 +57,7 @@ localhost and a production server. :
         "local": {
             "host": "http://localhost:8000/rest_api/v1/",
             "develop": true,
-            "insecure": false
+            "ssl-verify": false
         },
         "prod": {
             "host": "https://pdc.example.com/rest_api/v1/",

--- a/pdc_client/__init__.py
+++ b/pdc_client/__init__.py
@@ -97,7 +97,7 @@ class PDCClient(object):
     connections. The authentication token is automatically retrieved (if
     needed).
     """
-    def __init__(self, server, token=None, develop=False, ssl_verify=None, page_size=None):
+    def __init__(self, server, token=None, develop=None, ssl_verify=None, page_size=None):
         """Create new client instance.
 
         Once the class is instantiated, use it as you would use a regular


### PR DESCRIPTION
Fixes name of "ssl-verify" option in documentation (this confused me a lot) and "develop" option (which was ignored before).