### PR TITLE
plugin_helpers: Allow overriding 'dest' option

### DIFF
--- a/pdc_client/plugin_helpers.py
+++ b/pdc_client/plugin_helpers.py
@@ -96,7 +96,11 @@ def add_parser_arguments(parser, args, group=None, prefix=DATA_PREFIX):
         arg_name = kwargs.pop('arg', arg.replace('_', '-'))
         if 'metavar' not in kwargs:
             kwargs['metavar'] = arg.upper()
-        parser.add_argument('--' + arg_name, dest=prefix + arg, **kwargs)
+        if 'dest' in kwargs:
+            kwargs['dest'] = prefix + kwargs['dest']
+        else:
+            kwargs['dest'] = prefix + arg
+        parser.add_argument('--' + arg_name, **kwargs)
 
 
 def add_mutually_exclusive_args(parser, args, required=False, prefix=DATA_PREFIX):


### PR DESCRIPTION
plugin_helpers: Allow overriding 'dest' option.
This patch is used by patches which are about JIRA: PDC-1913 and JIRA:PDC-1914, will merge this to master first, and then merge the other two PRs.
