### PR TITLE
Use local development plugin directory

### DIFF
--- a/pdc_client/runner.py
+++ b/pdc_client/runner.py
@@ -40,7 +40,7 @@ from pdc_client.utils import pretty_print
 # The purpose of the plugins is to extend the default behaviour.
 LOCAL_DIR = os.path.join(os.path.dirname(__file__), 'plugins')
 INSTALLED_DIR = os.path.join('/usr/share/pdc-client', 'plugins')
-PLUGIN_DIRS = [LOCAL_DIR] if not os.path.exists(INSTALLED_DIR) else [INSTALLED_DIR]
+PLUGIN_DIRS = [LOCAL_DIR] if os.path.exists(LOCAL_DIR) else [INSTALLED_DIR]
 
 DEFAULT_PLUGINS = [
     'group_resource_permissions.py',


### PR DESCRIPTION
Prefer using local development plugin directory if exists instead of
installed one.

Replaces [this commit on PR](https://github.com/product-definition-center/pdc-client/pull/91/commits/64bea69836fd4bdaa321753e1438c44d609a4e81).