### PR TITLE
Fix passing ordering parameter

### DIFF
--- a/pdc_client/plugins/release_variant.py
+++ b/pdc_client/plugins/release_variant.py
@@ -105,8 +105,7 @@ class ReleaseVariantPlugin(PDCClientPlugin):
             if value is not None:
                 filters[key] = value
 
-        # TODO: ordering doesn't seem to be working correctly (arg order has to be reversed)
-        release_variants = self.client.get_paged(self.client["release-variants"]._, ordering=["variant_uid", "release"], **filters)
+        release_variants = self.client.get_paged(self.client["release-variants"]._, ordering="release,variant_uid", **filters)
 
         if args.json:
             print(json.dumps(list(release_variants)))

--- a/tests/release_variant/tests.py
+++ b/tests/release_variant/tests.py
@@ -91,7 +91,7 @@ class ProductVersionTestCase(CLITestCase):
         self.assertEqual(api.calls, {
             'release-variants': [
                 ('GET', {
-                    'ordering': ['variant_uid', 'release'],
+                    'ordering': "release,variant_uid",
                     'page': 1,
                 }),
             ],
@@ -114,7 +114,7 @@ class ProductVersionTestCase(CLITestCase):
             'release-variants': [
                 ('GET', {
                     'release': 'test-release-1.0',
-                    'ordering': ['variant_uid', 'release'],
+                    'ordering': "release,variant_uid",
                     'page': 1,
                 }),
             ],


### PR DESCRIPTION
On server-side, Django REST framework uses only the last ordering
parameter, where multiple fields can be separated with comma.