### PR TITLE
Bug fix for ssl_verify in old pdc_client

### DIFF
--- a/bin/pdc_client
+++ b/bin/pdc_client
@@ -169,7 +169,7 @@ if __name__ == "__main__":
         elif options.ca_cert:
             ssl_verify = options.ca_cert
         else:
-            ssl_verify = True
+            ssl_verify = None
         client = PDCClient(options.server, ssl_verify=ssl_verify)
         if options.comment:
             client.set_comment(options.comment)


### PR DESCRIPTION
The old pdc_client should set ssl_verify to None
to make configuration setting work.
This behavior is the same with new pdc.

Bug: PDC-2092