### PR TITLE
Documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,6 +3,8 @@
 [![Build Status](https://travis-ci.org/product-definition-center/pdc-client.svg?branch=master)](https://travis-ci.org/product-definition-center/pdc-client)
 [![Coverage Status](https://coveralls.io/repos/product-definition-center/pdc-client/badge.svg?branch=master&service=github)](https://coveralls.io/github/product-definition-center/pdc-client?branch=master)
 
+[Documentation](https://product-definition-center.github.io/pdc-client/)
+
 ## Installation
 
 You can obtain the client from the same repository where PDC server is.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,23 @@
+.. _api:
+
+Python API
+==========
+
+Usually you just need to import main class from the module.
+
+.. code-block:: python
+
+   from pdc_client import PDCClient
+
+Examples
+--------
+
+- `Creating global components based on imported source RPMs <https://github.com/product-definition-center/product-definition-center/blob/master/pdc/scripts/create_release_components.py>`__
+- `Find components with multiple contacts of same role <https://gist.github.com/lubomir/c78091bf286ee9764f99>`__
+
+Module pdc_client
+-----------------
+
+.. automodule:: pdc_client
+   :members:
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,8 +33,7 @@ from pdc_client import get_version
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-]
+extensions = ['sphinx.ext.autodoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -50,7 +49,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'PDC Client'
-copyright = u'2014-2016, PDC Devel Team'
+copyright = u'2017, Red Hat'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -1,0 +1,64 @@
+.. _config:
+
+Configuration
+=============
+
+The client can read server connection details from a configuration file.
+The configuration file should be located in
+``/etc/pdc.d/`` directory which contains ``fedora.json``, or in ``~/.config/pdc/client_config.json``.
+If both files are present, the system one is loaded first and the user
+configuration is applied on top of it (to add other options or overwrite
+existing ones).
+
+The configuration file should contain a JSON object, which maps server
+name to JSON object with details. The name is an arbitrary string used
+at client run time to identify which server you want to connect to.
+
+The details of a single server must contain at least one key: ``host``
+which specifies the URL to the API root (e.g.
+``http:://localhost:8000/rest_api/v1/`` for local instance).
+
+Other possible keys are:
+
+* ``token``
+
+    If specified, this token will be used for authentication. The client
+    will not try to obtain any token from the server.
+
+* ``ssl-verify``
+
+    If set to ``false``, server certificate will not be validated. See [Python requests documentation](http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification) for other possible values.
+
+* ``develop``
+
+    When set to ``true``, the client will not use any authentication at
+    all, not requesting a token nor sending any token with the requests.
+    This is only useful for working with servers which don't require
+    authentication.
+
+* ``plugins``
+
+    Plugins are configurable which depends on the user's needs.
+    If no plugins are configured, the default plugins will be used.
+    If plugins are configured, they will be merged to the default ones.
+
+Example
+-------
+
+This config defines connection to development server running on
+localhost and a production server:
+
+.. code-block:: json
+
+    {
+        "local": {
+            "host": "http://localhost:8000/rest_api/v1/",
+            "develop": true,
+            "ssl-verify": false
+        },
+        "prod": {
+            "host": "https://pdc.example.com/rest_api/v1/",
+            "plugins": ["permission.py", "release.py"]
+        }
+    }
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,7 +4,9 @@
    contain the root `toctree` directive.
 
 Welcome to PDC Client's documentation!
-===============================
+======================================
+
+PDC Client is Python API and scripts which simplify access to PDC server.
 
 Contents:
 
@@ -12,6 +14,11 @@ Contents:
    :maxdepth: 3
    :numbered:
 
+   install
+   config
+   api
+   pdc_client
+   pdc
    release
 
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,0 +1,26 @@
+.. _install:
+
+Installation
+============
+
+There are multiple ways to install PDC Client API and scripts on your system.
+
+a. Install from packages provided by your distribution.
+
+.. code-block:: bash
+
+   # install scripts
+   sudo yum install pdc-client
+
+   # install API for Python 3
+   sudo yum install python3-pdc-client
+
+   # install API for Python 2
+   sudo yum install python2-pdc-client
+
+b. Install from PyPI.
+
+.. code-block:: bash
+
+   pip install pdc-client
+

--- a/docs/source/pdc.rst
+++ b/docs/source/pdc.rst
@@ -1,0 +1,26 @@
+.. _pdc:
+
+Script pdc
+==========
+
+.. note::
+
+   Use argument ``-h`` or ``--help`` to get general help or help for a command.
+
+This has much more user friendly user interface than ``pdc_client``. A single
+invocation can perform multiple requests depending on what subcommand you used.
+
+The ``pdc`` client supports Bash completion if argcomplete Python package is installed.
+
+If you installed client from rpm package, the completion file ``pdc.bash`` has been
+installed to ``/etc/bash_completion.d/``.
+
+For developers or users who try to run ``pdc`` from source, to enable completion,
+run this in your terminal (assuming pdc is somewhere on path).
+
+.. code-block:: bash
+
+   eval "$(register-python-argcomplete pdc)"
+
+or put ``pdc.bash`` to ``/etc/bash_completion.d/``.
+

--- a/docs/source/pdc_client.rst
+++ b/docs/source/pdc_client.rst
@@ -1,0 +1,17 @@
+.. _pdc_client:
+
+Script pdc_client
+=================
+
+.. note::
+
+   Add argument ``-h`` or ``--help`` to get general help or help for a command.
+
+This is a very simple client. Essentially this is just a little more
+convenient than using ``curl`` manually. Each invocation of this client
+obtains a token and then performs a single request.
+
+This client is not meant for direct usage, but just as a helper for
+integrating with PDC from languages where it might be easier than
+performing the network requests manually.
+


### PR DESCRIPTION
Updates for [documentation pages](https://product-definition-center.github.io/pdc-client/).

Most of the things are taken from README file.

It also generates API documentation for `pdc_client` module.

This needs some improvement, e.g. add some inline examples to make it clear how it works.

**Can we also remove the Release section in documentation?** This is probably only internal thing and is documented in release checklist on JIRA.