### PR TITLE
Rollback codes on parent class of PDCClient

### DIFF
--- a/pdc_client/__init__.py
+++ b/pdc_client/__init__.py
@@ -135,7 +135,7 @@ class _SetAttributeWrapper(object):
         return super(_SetAttributeWrapper, self).__setattr__(name, value)
 
 
-class PDCClient(_SetAttributeWrapper):
+class PDCClient(object):
     """BeanBag wrapper specialized for PDC access.
 
     This class wraps general BeanBag.v1 objects, but provides easy-to-use
@@ -237,8 +237,6 @@ class PDCClient(_SetAttributeWrapper):
             if not token:
                 token = self.obtain_token()
             self.session.headers["Authorization"] = "Token %s" % token
-
-        self._initialized = True
 
     def obtain_token(self):
         """

--- a/tests/api/tests.py
+++ b/tests/api/tests.py
@@ -387,9 +387,6 @@ class PDCClientTestCase(unittest.TestCase):
         with self.assertRaises(BeanBagException):
             self.client['bad_resource'] = {}
 
-        with self.assertRaises(BeanBagException):
-            self.client.bad_resource = {}
-
     def test_str(self):
         self.assertEqual(str(self.client.products.fedora), self.url + '/products/fedora')
         self.assertEqual(str(self.client), self.url + '/')


### PR DESCRIPTION
Let PDCClient's parent class be object, but
not _SetAttributeWrapper, then we can set PDCClient's
attrs after or at the end of the __init__ function,
but not a BeanBag's attr.

JIRA: PDC-2429