### PR TITLE
Really fix deployment of documentation

### DIFF
--- a/docs/sphinx_deployment.mk
+++ b/docs/sphinx_deployment.mk
@@ -92,7 +92,7 @@ setup_gh_pages: init_gh_pages
 	@cd $(DEPLOY_DIR);\
 		git fetch origin;\
 		git reset --hard origin/$(DEPLOY_BRANCH_GITHUB);\
-		git branch --track $(DEPLOY_BRANCH_GITHUB) origin/$(DEPLOY_BRANCH_GITHUB)
+		git branch --set-upstream-to=origin/$(DEPLOY_BRANCH_GITHUB)
 	@echo "Now you can deploy to Github Pages with 'make generate' and then 'make deploy_gh_pages'"
 
 generate: html


### PR DESCRIPTION
The --track option only works when creating a new branch. What the script does is set the remote tracking branch. Using --set-upstream-to this should work repeatedly, even when already set.